### PR TITLE
Add username query parameter pre-fill on import page

### DIFF
--- a/src/pages/import.vue
+++ b/src/pages/import.vue
@@ -238,6 +238,12 @@ export default class Import extends Vue {
     if (this.clientId) {
       this.loadAppProfile()
     }
+
+    // Pre-fill username from query parameter (used by onboarding apps)
+    const qsUsername = (this.$route.query.username as string || '').toLowerCase().trim()
+    if (qsUsername && /^[a-z][a-z0-9.-]{2,15}$/.test(qsUsername) && !this.username) {
+      this.username = qsUsername
+    }
   }
 
   private beforeDestroy (): void {


### PR DESCRIPTION
## Summary

- Add support for a `username` query parameter in the OAuth flow
- When present, the username field on the import page is pre-filled, reducing friction for onboarding apps that already know the user's Hive username
- This is a UX convenience only — it does not affect authentication or authorization logic

## Motivation

Onboarding apps that create Hive accounts (e.g. gift card / invite systems) already know the new user's username. Currently, users must manually type it when importing their account on HiveSigner. Pre-filling this field eliminates one step in the multi-step login flow.

## Changes

- `src/pages/import.vue`: Read `username` from query params in `mounted()`, validate against Hive username regex (`/^[a-z][a-z0-9.-]{2,15}$/`), and pre-fill the form field via `PersistentFormsModule.saveImportUsername()`.

## Security

- Parameter only pre-fills the input field; no authentication bypass
- Input validated with `/^[a-z][a-z0-9.-]{2,15}$/` before use
- No keys or sensitive data in URL parameters
- Existing `redirect_uri` validation unchanged

## Test plan

- [ ] Navigate to `/oauth2/authorize?client_id=peakd.app&redirect_uri=...&scope=login&username=testuser123` with no imported accounts — should land on `/import` with "testuser123" pre-filled
- [ ] Same URL without `&username=` — username field should be empty (existing behavior unchanged)
- [ ] Invalid username (`&username=<script>alert(1)</script>`) — silently ignored, field stays empty
- [ ] Uppercase username (`&username=TestUser`) — lowercased to "testuser"
- [ ] Too-short username (`&username=ab`) — silently ignored
- [ ] User already has a username in progress, then navigates with `&username=other` — should NOT overwrite
- [ ] Full OAuth flow with pre-filled username: enter posting key, complete import, verify redirect works
- [ ] Direct navigation to `/import?username=testuser123` — username should still pre-fill

🤖 Generated with [Claude Code](https://claude.com/claude-code)